### PR TITLE
Fix JDBC column index bug

### DIFF
--- a/src/main/java/Utils/Jdbc.java
+++ b/src/main/java/Utils/Jdbc.java
@@ -60,15 +60,15 @@ public class Jdbc {
 		}
 	}
 
-	public static Object value(String sql, Object... args) {
-		ResultSet rs = execQuery(sql, args);
-		try {
-			if (rs.next()) {
-				return rs.getObject(0);
-			}
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-		return null;
-	}
+        public static Object value(String sql, Object... args) {
+                ResultSet rs = execQuery(sql, args);
+                try {
+                        if (rs.next()) {
+                                return rs.getObject(1);
+                        }
+                } catch (Exception e) {
+                        throw new RuntimeException(e);
+                }
+                return null;
+        }
 }


### PR DESCRIPTION
## Summary
- fix incorrect column index in `Jdbc.value`

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68457cdb3870832181fe935c9f5a6a84